### PR TITLE
21 makefile compiling last changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,8 @@ $(NAME): $(OBJ) $(ENDPOINT_OBJ) $(LIBFT)
 	$(PREFIX)$(CC) $(CFLAGS) $(OBJ)  $(ENDPOINT_OBJ) $(LIBFT) $(MLX) $(RLFLAGS) -o $@
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
-	$(PREFIX)mkdir -p $(dir $@)
-	$(PREFIX)$(CC) -MM $(CFLAGS) $< -MF $(@:.o=.d) -MT $@
-	$(PREFIX)$(CC) $(CFLAGS) -c $< -o $@
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
 
 -include $(OBJ:.o=.d)
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ $(NAME): $(OBJ) $(ENDPOINT_OBJ) $(LIBFT)
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c
 	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
+	$(CC) $(CFLAGS) -MMD -c $< -o $@
 
 -include $(OBJ:.o=.d)
 

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: dbisko <dbisko@student.42.fr>              +#+  +:+       +#+         #
+#    By: taretiuk <taretiuk@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/11/13 15:13:25 by dbisko            #+#    #+#              #
-#    Updated: 2025/02/10 15:28:52 by dbisko           ###   ########.fr        #
+#    Updated: 2025/03/14 11:15:27 by taretiuk         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -59,7 +59,7 @@ FILES = ft_atoi.c\
 		get_next_line.c
 
 CC = cc
-CFLAGS = -Wall -Wextra -Werror
+CFLAGS = -Wall -Wextra -Werror -g
 CFILES = $(FILES)
 OFILES = $(FILES:.c=.o)
 NAME = libft.a


### PR DESCRIPTION
Main changes to makefile. Now it outputs messages about recompiling only changed files:

-added I$(INCLUDE_DIR) in CFLAGS:
    This addition specifies the directory where the compiler should look for header files during compilation. $(INCLUDE_DIR) is a variable that represents the path to the include directory. This allows the project to include custom header files without needing to specify the full path each time.

- added @ symbol to @mkdir -p $(dir $@):
The @ symbol added to suppress the command output.

- added flag -MMD:
These flags are used to generate dependency files (.d files) for each source file.
      -MMD generates a dependency file for each object file that is created during the compilation, listing the header files that are included by the source file.